### PR TITLE
Use UTC instead of GMT.

### DIFF
--- a/classes/JSIS.js
+++ b/classes/JSIS.js
@@ -178,8 +178,8 @@ var JSIS = function() {
 		}
 
 		if( config.statsTimezoneText===null ) {
-			// Start with the text "GMT"
-			config.statsTimezoneText = 'GMT';
+			// Start with the text "UTC"
+			config.statsTimezoneText = 'UTC';
 
 			if( config.statsTimezone!=='+00:00' && config.statsTimezone!=='-00:00' ) {
 				config.statsTimezoneText += config.statsTimezone;

--- a/classes/LogReaders/eggdrop.js
+++ b/classes/LogReaders/eggdrop.js
@@ -90,7 +90,7 @@ var EggdropReader = function(logRelayer, channelConfig) {
 	var unknownDate = true;
 
 	this.currentDate = date.toString('ddd MMM dd yyyy');
-	this.tzData = 'GMT' + channelConfig.logTimezone;
+	this.tzData = 'UTC' + channelConfig.logTimezone;
 
 	// List of timestamps created without knowing the date
 	var timeStampsWithUnknownDate = [];

--- a/classes/LogReaders/irssi.js
+++ b/classes/LogReaders/irssi.js
@@ -86,7 +86,7 @@ var IrssiReader = function(logRelayer, channelConfig) {
 	var date = new XDate();
 
 	this.currentDate = null;
-	this.tzData = 'GMT' + channelConfig.logTimezone;
+	this.tzData = 'UTC' + channelConfig.logTimezone;
 
 	this.setDate = function(date) {
 		this.currentDate = date;

--- a/config.example.js
+++ b/config.example.js
@@ -51,7 +51,7 @@ var config = {
 			 * If your logs are not from the same timezone as the machine you're generating stats, setting this
 			 * will help you get the expected results. For timezone adjustment, also set statsTimezone.
 			 *
-			 * Format: +HH:MM or -HH:MM as offset from GMT, null to use server timezone (default)
+			 * Format: +HH:MM or -HH:MM as offset from UTC, null to use server timezone (default)
 			 * E.g.: +03:00 or -07:00
 			 *
 			 * @type {String}
@@ -95,7 +95,7 @@ var config = {
 			 * If you want to render the stats in a different timezone than the server is at, set this to the
 			 * timezone you want to render in. Also you might want to make sure logTimezone is correct.
 			 *
-			 * Format: +HH:MM or -HH:MM as offset from GMT, null to use server timezone (default)
+			 * Format: +HH:MM or -HH:MM as offset from UTC, null to use server timezone (default)
 			 * E.g.: +03:00 or -07:00
 			 *
 			 * @type {String}
@@ -103,11 +103,11 @@ var config = {
 			//statsTimezone: '+00:00',
 
 			/**
-			 * What text to show as being the timezone, in case you don't want to show "GMT-07:00"
+			 * What text to show as being the timezone, in case you don't want to show "UTC-07:00"
 			 *
 			 * @type {String}
 			 */
-			//statsTimezoneText: 'GMT',
+			//statsTimezoneText: 'UTC',
 
 			/**
 			 * Widgets to include, and in what order, comment out for default configuration (widgets/config.js)

--- a/lib/xdate.dev.js
+++ b/lib/xdate.dev.js
@@ -423,8 +423,8 @@ function parseISO(str, utcMode, xdate) {
 			m[10] || 0,
 			m[12] ? Number('0.' + m[12]) * 1000 : 0
 		));
-		if (m[13]) { // has gmt offset or Z
-			if (m[14]) { // has gmt offset
+		if (m[13]) { // has UTC offset or Z
+			if (m[14]) { // has UTC offset
 				d.setUTCMinutes(
 					d.getUTCMinutes() +
 					(m[15] == '-' ? 1 : -1) * (Number(m[16]) * 60 + (m[18] ? Number(m[18]) : 0))


### PR DESCRIPTION
GMT shouldn't be used anymore and for non-scientifical purposes it is allowed to simply replace GMT with UTC.

There was one string that looked too scary for me to start modifying in `lib/xdate.dev.js`:

```
proto.toUTCString = proto.toGMTString = function(formatString, settings, uniqueness) {
```
- https://en.wikipedia.org/wiki/UTC
- http://geography.about.com/od/timeandtimezones/a/gmtutc.htm
## 

Squashed commit of the following:

commit 8f4b3410e1a6c3169fbe42b58c1cb419b665756f
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Sun Jun 1 13:46:24 2014 +0300

```
classes/LogReaders/*: s/GMT/UTC/
```

commit b1bb8f4f4befa89e0b86c7361ac9df8b70d1af88
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Sun Jun 1 13:45:40 2014 +0300

```
classes/JSIS.js: s/GMT/UTC/
```

commit 8ed1cf7b960b88b73dd275a2d6f52bf28b566da2
Author: Mikaela Suomalainen mikaela.suomalainen@outlook.com
Date:   Sun Jun 1 13:44:57 2014 +0300

```
config.example.js: s/GMT/UTC/
```
